### PR TITLE
Clean that shit up

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,9 @@
         "titleBar.inactiveForeground": "#e7e7e799",
         "statusBar.background": "#e91e63",
         "statusBarItem.hoverBackground": "#ee4c83",
-        "statusBar.foreground": "#e7e7e7"
+        "statusBar.foreground": "#e7e7e7",
+        "statusBar.border": "#e91e63",
+        "titleBar.border": "#e91e63"
     },
     "peacock.color": "#E91E63"
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -89,6 +89,9 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions
 
+  var sortedTopPortfolioTags = {}
+  var sortedTopBlogTags = {}
+
   return graphql(`
     {
       blog: allMarkdownRemark(
@@ -201,7 +204,22 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       return p
     }, {})
 
-    console.log(topBlogTags)
+    console.log({ topBlogTags: topBlogTags })
+
+    var sortedTopBlogTagsArray = []
+    for (var tag in topBlogTags) {
+      sortedTopBlogTagsArray.push([tag, topBlogTags[tag]])
+    }
+
+    sortedTopBlogTagsArray.sort(function(a, b) {
+      return b[1] - a[1]
+    })
+
+    sortedTopBlogTagsArray.forEach(function(item) {
+      sortedTopBlogTags[item[0]] = item[1]
+    })
+
+    console.log({ sortedTopBlogTags: sortedTopBlogTags })
 
     blogTags = _.uniq(blogTags)
 
@@ -210,8 +228,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       path: "/blog/tags/",
       component: path.resolve(`src/templates/tags/blog-tags.js`),
       context: {
-        topTags: topBlogTags,
+        topTags: sortedTopBlogTags,
       },
+    })
+
+    createPage({
+      path: "/blog/",
+      component: path.resolve(`src/templates/blog.js`),
+      context: {
+        topTags: sortedTopBlogTags
+      }
     })
 
     // Make tag pages
@@ -224,7 +250,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         component: path.resolve(`src/templates/tag.js`),
         context: {
           tag,
-          topTags: topBlogTags,
+          topTags: sortedTopBlogTags,
           postType: "blog",
         },
       })
@@ -269,7 +295,22 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       return p
     }, {})
 
-    console.log(topPortfolioTags)
+    console.log({ topPortfolioTags: topPortfolioTags })
+
+    var sortedTopPortfolioTagsArray = []
+    for (var tag in topPortfolioTags) {
+      sortedTopPortfolioTagsArray.push([tag, topPortfolioTags[tag]])
+    }
+
+    sortedTopPortfolioTagsArray.sort(function(a, b) {
+      return b[1] - a[1]
+    })
+
+    sortedTopPortfolioTagsArray.forEach(function(item) {
+      sortedTopPortfolioTags[item[0]] = item[1]
+    })
+
+    console.log({ sortedTopPortfolioTags: sortedTopPortfolioTags })
 
     portfolioTags = _.uniq(portfolioTags)
 
@@ -278,8 +319,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       path: "/portfolio/tags/",
       component: path.resolve(`src/templates/tags/portfolio-tags.js`),
       context: {
-        topTags: topPortfolioTags,
+        topTags: sortedTopPortfolioTags,
       },
+    })
+
+    createPage({
+      path: "/portfolio/",
+      component: path.resolve(`src/templates/portfolio.js`),
+      context: {
+        topTags: sortedTopPortfolioTags
+      }
     })
 
     // Make tag pages
@@ -292,7 +341,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         component: path.resolve(`src/templates/tag.js`),
         context: {
           tag,
-          topTags: topPortfolioTags,
+          topTags: sortedTopPortfolioTags,
           postType: "portfolio",
         },
       })

--- a/src/components/common/colorSwitcher.js
+++ b/src/components/common/colorSwitcher.js
@@ -263,7 +263,7 @@ export default class ColorSwitcher extends Component {
           :
           null}
 
-        <button onClick={this.toggleModal} id="colorSwitcher" type={"button"}>
+        <button onClick={this.toggleModal} aria-label="Change Site Color" id="colorSwitcher" type={"button"}>
           <FontAwesomeIcon icon="palette"></FontAwesomeIcon>
         </button>
 

--- a/src/components/common/mainMenu.js
+++ b/src/components/common/mainMenu.js
@@ -37,7 +37,7 @@ export default class MainMenu extends Component {
 
         </nav>
 
-        <button id="mobileMenuToggle" onClick={this.toggleMenu} type={"button"}>
+        <button id="mobileMenuToggle" aria-label="Menu" onClick={this.toggleMenu} type={"button"}>
             <FontAwesomeIcon icon="bars"></FontAwesomeIcon>
         </button>
     </>)

--- a/src/components/fontawesome.js
+++ b/src/components/fontawesome.js
@@ -1,4 +1,4 @@
-import { library } from "@fortawesome/fontawesome-svg-core"
+import { library, config } from "@fortawesome/fontawesome-svg-core"
 import { fab } from "@fortawesome/free-brands-svg-icons"
 import {
   faCheckSquare,
@@ -29,6 +29,8 @@ import {
   faCamera,
   faCircleNotch
 } from "@fortawesome/free-solid-svg-icons"
+
+config.autoAddCss = false
 
 library.add(
   fab,

--- a/src/scss/components/atoms/_tags.scss
+++ b/src/scss/components/atoms/_tags.scss
@@ -50,9 +50,7 @@
     justify-content: center;
     margin-bottom: 1em;
 
-    &--portfolio {
-      grid-template-columns: repeat(3, 1fr);
-    }
+
 
     div {
       min-height: 8rem;
@@ -65,8 +63,19 @@
     img {
       margin: 0 auto;
       width: 100%;
-      height: 100%;
-      object-fit: contain;
+      height: auto;
+      display: block;
+
+      object-fit: cover;
+    }
+
+    &--portfolio {
+      grid-template-columns: repeat(3, 1fr);
+
+      img{
+        height: 100%;
+        object-fit: contain;
+      }
     }
   }
 }

--- a/src/scss/components/blog/_blog.scss
+++ b/src/scss/components/blog/_blog.scss
@@ -55,6 +55,9 @@
       width: auto;
       height: 100%;
       display: block;
+
+      object-fit: cover;
+
     }
   }
 
@@ -239,6 +242,11 @@
 
   &--small {
     .blog__card {
+
+      .featuredImage{
+        height: auto;
+        width: 100%;
+      }
       .post__title {
         font-size: 1.5rem;
       }

--- a/src/scss/vendor/_vendor.scss
+++ b/src/scss/vendor/_vendor.scss
@@ -1,2 +1,4 @@
 @import "prism";
 @import "carbonAds";
+
+@import 'node_modules/@fortawesome/fontawesome-svg-core/styles'

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -7,25 +7,17 @@ import PageTitle from "../components/pageTitle"
 import BlogCard from "../components/blog/blogCard"
 
 import RssCard from "../components/blog/rssCard"
-import tagIcons from "../templates/tags/tag-icons"
+import tagIcons from "./tags/tag-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const _ = require("lodash")
 
-const Blog = ({ data }) => {
+const Blog = ({ data, pageContext }) => {
   const { edges: posts } = data.allMarkdownRemark
-  let tags = []
-  // Iterate through each post, putting all found tags into `tags`
-  _.forEach(posts, ({ node: post }) => {
-    return (tags = tags.concat(post.frontmatter.tags))
-  })
-
-  var map = tags.reduce(function(p, c) {
-    p[c] = (p[c] || 0) + 1
-    return p
-  }, {})
-  var topTags = Object.keys(map).sort(function(a, b) {
-    return map[a] < map[b]
+  const tags = pageContext.topTags
+    // Iterate through each post, putting all found tags into `tags`
+  var topTags = Object.keys(tags).sort(function(a, b) {
+    return tags[a] < tags[b]
   })
 
   return (

--- a/src/templates/portfolio.js
+++ b/src/templates/portfolio.js
@@ -6,25 +6,17 @@ import SEO from "../components/seo"
 import PageTitle from "../components/pageTitle"
 import ProjectCard from "../components/portfolio/projectCard"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import tagIcons from "../templates/tags/tag-icons"
+import tagIcons from "./tags/tag-icons"
 
 const _ = require("lodash")
 
-const Blog = ({ data }) => {
+const Blog = ({ data, pageContext }) => {
   const { edges: posts } = data.allMarkdownRemark
 
-  let tags = []
-  // Iterate through each post, putting all found tags into `tags`
-  _.forEach(posts, ({ node: post }) => {
-    return (tags = tags.concat(post.frontmatter.tags))
-  })
-
-  var map = tags.reduce(function(p, c) {
-    p[c] = (p[c] || 0) + 1
-    return p
-  }, {})
-  var topTags = Object.keys(map).sort(function(a, b) {
-    return map[a] < map[b]
+  const tags = pageContext.topTags
+    // Iterate through each post, putting all found tags into `tags`
+  var topTags = Object.keys(tags).sort(function(a, b) {
+    return tags[a] < tags[b]
   })
 
   return (

--- a/src/templates/tags/blog-tags.js
+++ b/src/templates/tags/blog-tags.js
@@ -33,7 +33,7 @@ class TagRoute extends React.Component {
                 return (
                   <Link to={tagLink} className="tag__card">
                     <h2>
-                      <FontAwesomeIcon fixedWidth icon={tagIcons[tag]} spin={(tag === "Animation" ? true : false)} />
+                      <FontAwesomeIcon fixedWidth icon={tagIcons[tag]} />
                       {tag}
                     </h2>{" "}
                     <h4>


### PR DESCRIPTION
Fixed a weird issue where the TopTags lists wouldn't sort properly in Brave. By sorting in gatsby-node and then injected that in as context, it allows a more consistent list of top tags, instead of having to sort every time we get it. 